### PR TITLE
feat: expand flash remote control and insert submodes

### DIFF
--- a/nvim/lua/custom/plugins/flash.lua
+++ b/nvim/lua/custom/plugins/flash.lua
@@ -32,6 +32,24 @@ return {
         shade = 4,
       },
     },
+    remote_op = {
+      restore = true,
+      motion = true,
+    },
+    modes = {
+      remote = {
+        jump = {
+          autojump = false,
+        },
+        label = {
+          autojump = false,
+        },
+        remote_op = {
+          restore = true,
+          motion = true,
+        },
+      },
+    },
   },
   -- stylua: ignore
   keys = {
@@ -67,7 +85,6 @@ return {
       "<tab>",
       mode = {
         "n",
-        "i",     --
       },
       function() -- <-- Why are some functions defined as variables, some are given names as an actual function, and still others like this are passed raw?
         local Flash = require("flash")

--- a/nvim/lua/custom/plugins/submode.lua
+++ b/nvim/lua/custom/plugins/submode.lua
@@ -1,0 +1,130 @@
+return {
+  'pogyomo/submode.nvim',
+  event = 'VeryLazy',
+  config = function()
+    local submode = require('submode')
+    local remote = require('custom.remote_ops')
+
+    local function leave_and(fn)
+      return function()
+        submode.leave()
+        fn()
+      end
+    end
+
+    local function trigger(event, data)
+      vim.api.nvim_exec_autocmds('User', { pattern = event, data = data or {} })
+    end
+
+    local function create_insert_remote()
+      submode.create('InsertRemoteOps', {
+        mode = 'i',
+        enter = '<Tab>',
+        leave = { '<Esc>', '<Tab>', '<CR>' },
+        leave_when_mode_changed = true,
+        hook = {
+          on_enter = function()
+            trigger('InsertRemoteOpsEnter')
+          end,
+          on_leave = function()
+            trigger('InsertRemoteOpsLeave')
+          end,
+        },
+        default = function(register)
+          register('p', leave_and(remote.start_put_after))
+          register('P', leave_and(remote.start_put_before))
+          register('y', leave_and(remote.start_yank))
+          register('d', leave_and(remote.start_delete))
+          register('c', leave_and(remote.start_change))
+          register('r', leave_and(remote.start_replace))
+          register('R', leave_and(remote.start_replace_mode))
+
+          register('<leader>sa', leave_and(remote.start_surround_a))
+          register('<leader>sd', leave_and(remote.start_surround_d))
+          register('<leader>sf', leave_and(remote.start_surround_f))
+          register('<leader>sF', leave_and(remote.start_surround_F))
+          register('<leader>sh', leave_and(remote.start_surround_h))
+          register('<leader>sr', leave_and(remote.start_surround_r))
+        end,
+      })
+    end
+
+    local word_guard_ns = vim.api.nvim_create_namespace('submode-word-motion-guard')
+    local allowed = {
+      w = true,
+      W = true,
+      e = true,
+      E = true,
+      b = true,
+      B = true,
+    }
+    local guard_active = false
+
+    local function attach_guard()
+      if guard_active then
+        return
+      end
+      guard_active = true
+      vim.on_key(function(char)
+        if submode.mode() ~= 'WordMotionRestore' then
+          return
+        end
+        local key = vim.fn.keytrans(char)
+        if not allowed[key] then
+          submode.leave()
+        end
+      end, word_guard_ns)
+    end
+
+    local function detach_guard()
+      if not guard_active then
+        return
+      end
+      guard_active = false
+      vim.on_key(nil, word_guard_ns)
+    end
+
+    local function feed_normal(keys)
+      vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(keys, true, false, true), 'n', false)
+    end
+
+    local function create_word_restore()
+      submode.create('WordMotionRestore', {
+        mode = 'n',
+        enter = '<Tab>',
+        leave = { '<Esc>', '<Tab>' },
+        leave_when_mode_changed = true,
+        hook = {
+          on_enter = function()
+            attach_guard()
+            trigger('WordMotionRestoreEnter')
+          end,
+          on_leave = function()
+            detach_guard()
+            trigger('WordMotionRestoreLeave')
+          end,
+        },
+        default = function(register)
+          local function passthrough(key)
+            register(key, function()
+              feed_normal(key)
+            end)
+          end
+
+          passthrough('w')
+          passthrough('W')
+          passthrough('e')
+          passthrough('E')
+          passthrough('b')
+          passthrough('B')
+          register('<Tab>', function()
+            submode.leave()
+          end)
+        end,
+      })
+    end
+
+    create_insert_remote()
+    create_word_restore()
+  end,
+}

--- a/nvim/lua/custom/remote_ops.lua
+++ b/nvim/lua/custom/remote_ops.lua
@@ -1,0 +1,164 @@
+local M = {}
+
+local function termcodes(keys)
+  return vim.api.nvim_replace_termcodes(keys, true, false, true)
+end
+
+local function feed(keys)
+  vim.api.nvim_feedkeys(termcodes(keys), 'n', false)
+end
+
+local function in_insert()
+  local mode = vim.fn.mode()
+  return mode:sub(1, 1) == 'i'
+end
+
+local function start_sequence(seq, opts)
+  opts = opts or {}
+  local prefix = ''
+  if in_insert() then
+    prefix = '<C-o>'
+  end
+  feed(prefix .. seq)
+  if opts.remote ~= false then
+    vim.schedule(function()
+      local ok, flash = pcall(require, 'flash')
+      if ok then
+        flash.remote(opts.remote_opts)
+      end
+    end)
+  end
+  if type(opts.post) == 'function' then
+    vim.schedule(opts.post)
+  end
+end
+
+local function range_positions(type_)
+  local start_pos = vim.fn.getpos("'[")
+  local end_pos = vim.fn.getpos("']")
+  local start_row = start_pos[2] - 1
+  local start_col = start_pos[3] - 1
+  local end_row = end_pos[2] - 1
+  local end_col = end_pos[3]
+  local linewise = type_:sub(1, 1) == 'V' or type_ == 'line'
+  local block = type_:sub(1, 1) == '\22'
+
+  if linewise then
+    return {
+      mode = 'line',
+      start_row = start_row,
+      end_row = end_pos[2],
+    }
+  end
+
+  if block then
+    -- Treat block-wise selections as characterwise replacements.
+    type_ = 'char'
+  end
+
+  return {
+    mode = 'char',
+    start_row = start_row,
+    start_col = start_col,
+    end_row = end_row,
+    end_col = end_col,
+  }
+end
+
+local function replace_range(lines, type_)
+  local bufnr = vim.api.nvim_get_current_buf()
+  local range = range_positions(type_)
+
+  if range.mode == 'line' then
+    vim.api.nvim_buf_set_lines(bufnr, range.start_row, range.end_row, false, lines)
+    return
+  end
+
+  vim.api.nvim_buf_set_text(bufnr, range.start_row, range.start_col, range.end_row, range.end_col, lines)
+end
+
+local function get_register()
+  local reg = vim.v.register
+  if reg == '' then
+    reg = '"'
+  end
+  local regtype = vim.fn.getregtype(reg)
+  local lines = vim.fn.getreg(reg, 1, true)
+  return reg, regtype, lines
+end
+
+local function normalize_lines(lines, regtype)
+  if regtype:sub(1, 1) == 'V' and lines[#lines] ~= '' then
+    table.insert(lines, '')
+  end
+  return lines
+end
+
+local function start_custom_operator(func)
+  vim.go.operatorfunc = "v:lua.require'custom.remote_ops'." .. func
+  local prefix = ''
+  if in_insert() then
+    prefix = '<C-o>'
+  end
+  feed(prefix .. 'g@')
+  vim.schedule(function()
+    local ok, flash = pcall(require, 'flash')
+    if ok then
+      flash.remote()
+    end
+  end)
+end
+
+function M.start_operator(seq, opts)
+  start_sequence(seq, vim.tbl_extend('force', { remote = true }, opts or {}))
+end
+
+function M.start_put_after()
+  start_custom_operator('operator_put_after')
+end
+
+function M.start_put_before()
+  start_custom_operator('operator_put_before')
+end
+
+function M.start_yank()
+  M.start_operator('y')
+end
+
+function M.start_delete()
+  M.start_operator('d')
+end
+
+function M.start_change()
+  M.start_operator('c')
+end
+
+function M.start_replace()
+  M.start_operator('gr')
+end
+
+function M.start_replace_mode()
+  start_sequence('R', { remote = false })
+end
+
+local surround_targets = { 'a', 'd', 'f', 'F', 'h', 'r' }
+
+for _, key in ipairs(surround_targets) do
+  M['start_surround_' .. key] = function()
+    start_sequence('<leader>s' .. key, { remote = true })
+  end
+end
+
+function M.operator_put_after(type_)
+  local _, regtype, lines = get_register()
+  lines = normalize_lines(vim.deepcopy(lines), regtype)
+  replace_range(lines, type_)
+end
+
+function M.operator_put_before(type_)
+  local _, regtype, lines = get_register()
+  lines = normalize_lines(vim.deepcopy(lines), regtype)
+  replace_range(lines, type_)
+end
+
+return M


### PR DESCRIPTION
## Summary
- configure Flash remote options so operator motions stay selectable and stop the 2D jump mapping from loading in insert mode
- add a submode.nvim setup that exposes remote-ready put/yank/change/delete/surround operators from insert mode and restores native word motions in normal mode
- implement reusable helper routines for remote operators to drive put/surround flows and emit User events for Reactive integrations

## Testing
- n/a (nvim binary unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911998dacbc8328bc74f2c363b44406)