### PR TITLE
Add insert submode for Flash remote workflows

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -190,6 +190,16 @@ vim.keymap.set('n', '<leader>Y', '"+Y', {
   desc = 'Yank to end of line to system clipboard',
 })
 
+do
+  local remote_ops = require 'custom.remote_ops'
+  vim.keymap.set('n', '<leader>p', function()
+    remote_ops.start_put('p')
+  end, { desc = 'Remote put after selection' })
+  vim.keymap.set('n', '<leader>P', function()
+    remote_ops.start_put('P')
+  end, { desc = 'Remote put before selection' })
+end
+
 -- Delete to void register
 vim.keymap.set('n', '<leader><leader>d', '"_d', {
   desc = 'Delete into void register',

--- a/nvim/lua/custom/plugins/flash.lua
+++ b/nvim/lua/custom/plugins/flash.lua
@@ -32,24 +32,24 @@ return {
         shade = 4,
       },
     },
-    -- remote_op = {
-    --   restore = true,
-    --   motion = true,
-    -- },
-    -- modes = {
-    --   remote = {
-    --     jump = {
-    --       autojump = false,
-    --     },
-    --     label = {
-    --       autojump = false,
-    --     },
-    --     remote_op = {
-    --       restore = true,
-    --       motion = true,
-    --     },
-    --   },
-    -- },
+    remote_op = {
+      restore = true,
+      motion = true,
+    },
+    modes = {
+      remote = {
+        jump = {
+          autojump = false,
+        },
+        label = {
+          autojump = false,
+        },
+        remote_op = {
+          restore = true,
+          motion = true,
+        },
+      },
+    },
   },
   -- stylua: ignore
   keys = {

--- a/nvim/lua/custom/plugins/reactive.lua
+++ b/nvim/lua/custom/plugins/reactive.lua
@@ -6,5 +6,21 @@ return {
       cursor = false,
       modemsg = true,
     },
+    configs = {
+      submodes = {
+        modes = {
+          InsertRemoteOps = {
+            hl = {
+              ModeMsg = { link = 'WarningMsg' },
+            },
+          },
+          WordMotionRestore = {
+            hl = {
+              ModeMsg = { link = 'Question' },
+            },
+          },
+        },
+      },
+    },
   },
 }

--- a/nvim/lua/custom/plugins/submode.lua
+++ b/nvim/lua/custom/plugins/submode.lua
@@ -1,0 +1,72 @@
+return {
+  'pogyomo/submode.nvim',
+  event = 'VeryLazy',
+  dependencies = {
+    'folke/flash.nvim',
+  },
+  config = function()
+    local submode = require('submode')
+    local remote = require('custom.remote_ops')
+
+    local function leave()
+      submode.leave()
+      remote.cancel()
+    end
+
+    submode.create('InsertRemoteOps', {
+      mode = 'i',
+      show_mode = true,
+      enter = '<Tab>',
+      leave = { '<Esc>' },
+      leave_when_mode_changed = true,
+      register = function(register)
+        register('<Esc>', leave)
+        register('<Tab>', function()
+          if not remote.finish_at_cursor() then
+            leave()
+          end
+        end)
+        register('<CR>', function()
+          if not remote.finish_at_cursor() then
+            leave()
+          end
+        end)
+        register('p', function()
+          remote.start_put('p', { from_insert = true })
+        end)
+        register('P', function()
+          remote.start_put('P', { from_insert = true })
+        end)
+        register('y', remote.operator('y', { from_insert = true }))
+        register('Y', remote.operator('y', { from_insert = true, register = '+' }))
+        register('d', remote.operator('d', { from_insert = true }))
+        register('c', remote.operator('c', { from_insert = true }))
+        register('r', remote.execute_normal('r', { from_insert = true }))
+        register('R', remote.execute_normal('R', { from_insert = true }))
+        register('<leader>sa', remote.execute_normal('<leader>sar', { from_insert = true }))
+        register('<leader>sd', remote.execute_normal('<leader>sdr', { from_insert = true }))
+        register('<leader>sf', remote.execute_normal('<leader>sfr', { from_insert = true }))
+        register('<leader>sF', remote.execute_normal('<leader>sFr', { from_insert = true }))
+        register('<leader>sh', remote.execute_normal('<leader>shr', { from_insert = true }))
+        register('<leader>sr', remote.execute_normal('<leader>srr', { from_insert = true }))
+      end,
+    })
+
+    submode.create('WordMotionRestore', {
+      mode = 'n',
+      show_mode = true,
+      enter = '<Tab>',
+      leave = { '<Esc>' },
+      leave_when_mode_changed = true,
+      register = function(register)
+        register('<Tab>', leave)
+        register('w', 'w')
+        register('W', 'W')
+        register('e', 'e')
+        register('E', 'E')
+        register('b', 'b')
+        register('B', 'B')
+      end,
+    })
+  end,
+}

--- a/nvim/lua/custom/remote_ops.lua
+++ b/nvim/lua/custom/remote_ops.lua
@@ -1,0 +1,150 @@
+local M = {}
+
+local state = {
+  pending = nil,
+}
+
+local function feed(keys, opts)
+  opts = opts or {}
+  local seq = keys
+  if opts.from_insert then
+    seq = '<C-o>' .. seq
+  end
+  local termcodes = vim.api.nvim_replace_termcodes(seq, true, false, true)
+  vim.api.nvim_feedkeys(termcodes, 'n', false)
+end
+
+local function restore_register(name, value, regtype)
+  if name then
+    vim.fn.setreg(name, value, regtype)
+  end
+end
+
+local function get_register_content(preferred)
+  local reg = preferred
+  if not reg or reg == '' then
+    reg = vim.v.register ~= '' and vim.v.register or '"'
+  end
+  local content = vim.fn.getreg(reg)
+  local regtype = vim.fn.getregtype(reg)
+  return reg, content, regtype
+end
+
+local function split_register_lines(content, regtype)
+  local lines = vim.split(content, '\n', true)
+  if regtype == 'V' or regtype == 'v' then
+    if lines[#lines] == '' then
+      table.remove(lines)
+    end
+  end
+  if #lines == 0 then
+    lines = { '' }
+  end
+  return lines
+end
+
+local function delete_range(range_type)
+  local start_pos = vim.api.nvim_buf_get_mark(0, '[')
+  local end_pos = vim.api.nvim_buf_get_mark(0, ']')
+  if not start_pos or not end_pos then
+    return false, 'missing range marks'
+  end
+
+  local sr, sc = start_pos[1] - 1, start_pos[2]
+  local er, ec = end_pos[1] - 1, end_pos[2]
+
+  if range_type == 'line' then
+    ec = 0
+    er = er + 1
+    vim.api.nvim_buf_set_lines(0, sr, er, false, {})
+    return true
+  elseif range_type == 'block' then
+    return false, 'blockwise put is not supported yet'
+  else
+    ec = ec + 1
+    vim.api.nvim_buf_set_text(0, sr, sc, er, ec, {})
+    return true
+  end
+end
+
+local function do_put(pending, range_type)
+  local register, content, regtype = get_register_content(pending.register)
+  local default_content = vim.fn.getreg('"')
+  local default_type = vim.fn.getregtype('"')
+  local ok, err = delete_range(range_type)
+  if not ok then
+    vim.notify(string.format('flash put: %s', err), vim.log.levels.WARN)
+    return
+  end
+  local lines = split_register_lines(content, regtype)
+  vim.fn.setreg('"', content, regtype)
+  local status, put_err = pcall(vim.api.nvim_put, lines, regtype == 'V', pending.which == 'p', true)
+  vim.fn.setreg('"', default_content, default_type)
+  if not status then
+    vim.notify(string.format('flash put failed: %s', put_err), vim.log.levels.ERROR)
+  end
+  restore_register(register, content, regtype)
+end
+
+function M.start_put(which, opts)
+  opts = opts or {}
+  state.pending = {
+    which = which or 'p',
+    register = opts.register,
+  }
+  vim.go.operatorfunc = 'v:lua.__flash_put_handler'
+  local prefix = ''
+  if opts.register and opts.register ~= '' then
+    prefix = '"' .. opts.register
+  end
+  feed(prefix .. 'g@r', { from_insert = opts.from_insert })
+end
+
+function M.put_handler(range_type)
+  local pending = state.pending
+  state.pending = nil
+  if not pending then
+    return
+  end
+  do_put(pending, range_type)
+end
+
+function M.operator(op, opts)
+  opts = opts or {}
+  local prefix = ''
+  if opts.register and opts.register ~= '' then
+    prefix = '"' .. opts.register
+  end
+  return function()
+    feed(prefix .. op .. 'r', { from_insert = opts.from_insert })
+  end
+end
+
+function M.execute_normal(cmd, opts)
+  opts = opts or {}
+  return function()
+    feed(cmd, { from_insert = opts.from_insert })
+  end
+end
+
+function M.finish_at_cursor()
+  if not state.pending then
+    return false
+  end
+  local pending = state.pending
+  state.pending = nil
+  do_put(pending, 'char')
+  return true
+end
+
+function M.cancel()
+  state.pending = nil
+end
+
+return M
+
+---@diagnostic disable-next-line: lowercase-global
+function _G.__flash_put_handler(range_type)
+  require('custom.remote_ops').put_handler(range_type)
+end
+


### PR DESCRIPTION
## Summary
- configure flash remote mode to avoid autojump so operators can pick motions
- add reusable remote put helper and expose new normal/insert keymaps via submode.nvim
- highlight custom submodes with reactive.nvim for better visibility

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912a63f15f083289f64a53154777257)